### PR TITLE
tls: send bool instead of closing channel on close

### DIFF
--- a/tls/tls.go
+++ b/tls/tls.go
@@ -49,7 +49,7 @@ func (c *MyConn) Write(b []byte) (n int, err error) {
 }
 
 func (c *MyConn) Close() error {
-	close(c.done)
+	c.done <- true
 	return nil
 }
 


### PR DESCRIPTION
Please correct me if I'm wrong, but I _think_ we need to send a bool to the `done` channel instead of closing it on `Close()`. 

Otherwise it'll to run into a false positive whenever the HTTP body is too short / invalid.

```console
$ cat fab63f584b38af05cadc7315857fd9d5a1596a62.output
panic: close of closed channel

goroutine 3122 [running]:
github.com/dvyukov/go-fuzz-corpus/tls.(*MyConn).Close(0xc0003dd880, 0x71ca60, 0x75cb60)
        /go/src/github.com/dvyukov/go-fuzz-corpus/tls/tls.go:52 +0x47
crypto/tls.(*Conn).Close(0xc00041e380, 0xc000414b28, 0x7c3870)
        /usr/local/go/src/crypto/tls/conn.go:1291 +0x1ae
net/http.(*conn).close(0xc000414aa0)
        /usr/local/go/src/net/http/server.go:1668 +0x5a
net/http.(*conn).serve.func1(0xc000414aa0)
        /usr/local/go/src/net/http/server.go:1776 +0x152
net/http.(*conn).serve(0xc000414aa0, 0x8185c0, 0xc00009cea0)
        /usr/local/go/src/net/http/server.go:1795 +0x4f2
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:2933 +0x51a

goroutine 1 [runnable]:
github.com/dvyukov/go-fuzz-corpus/tls.Fuzz(0x7fa36fe64000, 0x5, 0x5, 0x3)
        /go/src/github.com/dvyukov/go-fuzz-corpus/tls/tls.go:119 +0xd3
go-fuzz-dep.Main(0xc000059f70, 0x1, 0x1)
        go-fuzz-dep/main.go:36 +0x1ad
main.main()
        github.com/dvyukov/go-fuzz-corpus/tls/go.fuzz.main/main.go:15 +0x52

goroutine 18 [chan receive]:
github.com/dvyukov/go-fuzz-corpus/tls.MyListener.Accept(0xc0000960c0, 0xc01e9bf892, 0x1e9bf8920009ced0, 0x5e7e4eec, 0xc00005ae30)
        /go/src/github.com/dvyukov/go-fuzz-corpus/tls/tls.go:22 +0x56
crypto/tls.(*listener).Accept(0xc0000c2a60, 0xc00005ae80, 0x18, 0xc000082600, 0x6e3aba)
        /usr/local/go/src/crypto/tls/tls.go:55 +0x4f
net/http.(*Server).Serve(0xc0001181c0, 0x817c40, 0xc0000c2a60, 0x0, 0x0)
        /usr/local/go/src/net/http/server.go:2901 +0x366
github.com/dvyukov/go-fuzz-corpus/tls.init.0.func2(0x817c40, 0xc0000c2a60)
        /go/src/github.com/dvyukov/go-fuzz-corpus/tls/tls.go:104 +0xe6
created by github.com/dvyukov/go-fuzz-corpus/tls.init.0
        /go/src/github.com/dvyukov/go-fuzz-corpus/tls/tls.go:100 +0x317
```

```console
$ cat fab63f584b38af05cadc7315857fd9d5a1596a62.quoted 
        "OPTIO"
```

After setting up an example test case with the fix I'm including, the fuzzer will no longer produces the false positive.